### PR TITLE
Fix typo in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -212,7 +212,7 @@ To remove all resources created by this example do the following:
 2. Remove the customer policy from the node and master IAM roles
 3. Delete the cluster with kops:
 
-    kubectl delete cluster awscni.k8s.local --yes
+    kops delete cluster awscni.k8s.local --yes
 
 == License Summary
 


### PR DESCRIPTION
There is a small typo in README.adoc: "kops" should be used instead of "kubectl".

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
